### PR TITLE
Fix dbcheck package structure

### DIFF
--- a/backend/cmd/dbcheck/check_keywords/check_keywords.go
+++ b/backend/cmd/dbcheck/check_keywords/check_keywords.go
@@ -25,7 +25,7 @@ func Run() {
 	dbName := "trendscout"
 
 	// 接続文字列を作成
-	connString := fmt.Sprintf("postgres://%s:%s@%s:5432/%s", 
+	connString := fmt.Sprintf("postgres://%s:%s@%s:5432/%s",
 		dbUser, dbPassword, dbHost, dbName)
 
 	// データベースに接続
@@ -118,8 +118,8 @@ func Run() {
 	}
 
 	// キーワードをテスト挿入
-	_, err = pgPool.Exec(ctx, 
-		"INSERT INTO keywords (user_id, keyword) VALUES ($1, $2) ON CONFLICT (user_id, keyword) DO NOTHING", 
+	_, err = pgPool.Exec(ctx,
+		"INSERT INTO keywords (user_id, keyword) VALUES ($1, $2) ON CONFLICT (user_id, keyword) DO NOTHING",
 		adminID, "test_keyword")
 	if err != nil {
 		log.Fatalf("キーワード挿入エラー: %v", err)
@@ -154,4 +154,4 @@ func Run() {
 	}
 
 	fmt.Printf("\n合計 %d 件のキーワードレコードが見つかりました\n", count)
-} 
+}

--- a/backend/cmd/dbcheck/check_user/check_user.go
+++ b/backend/cmd/dbcheck/check_user/check_user.go
@@ -25,7 +25,7 @@ func Run() {
 	dbName := "trendscout"
 
 	// 接続文字列を作成
-	connString := fmt.Sprintf("postgres://%s:%s@%s:5432/%s", 
+	connString := fmt.Sprintf("postgres://%s:%s@%s:5432/%s",
 		dbUser, dbPassword, dbHost, dbName)
 
 	// データベースに接続
@@ -100,4 +100,4 @@ func Run() {
 	fmt.Println("\nバックエンドサーバー接続チェック...")
 	fmt.Println("バックエンドサーバーに接続するには以下を実行してください:")
 	fmt.Println("curl http://localhost:8080/")
-} 
+}

--- a/backend/cmd/dbcheck/main.go
+++ b/backend/cmd/dbcheck/main.go
@@ -17,7 +17,7 @@ func main() {
 	}
 
 	command := os.Args[1]
-	
+
 	switch strings.ToLower(command) {
 	case "users":
 		check_user.Run()
@@ -36,4 +36,4 @@ func printUsage() {
 	fmt.Println("  users     - ユーザーテーブルを確認")
 	fmt.Println("  keywords  - キーワードテーブルを確認")
 	fmt.Println("  reset     - 管理者パスワードをリセット")
-} 
+}

--- a/backend/cmd/dbcheck/reset_password/reset_password.go
+++ b/backend/cmd/dbcheck/reset_password/reset_password.go
@@ -26,7 +26,7 @@ func Run() {
 	dbName := "trendscout"
 
 	// 接続文字列を作成
-	connString := fmt.Sprintf("postgres://%s:%s@%s:5432/%s", 
+	connString := fmt.Sprintf("postgres://%s:%s@%s:5432/%s",
 		dbUser, dbPassword, dbHost, dbName)
 
 	// データベースに接続
@@ -54,7 +54,7 @@ func Run() {
 	var userID int
 	var email string
 	var passwordHash string
-	
+
 	err = pgPool.QueryRow(ctx, "SELECT id, email, password_hash FROM users WHERE email = 'admin@example.com'").Scan(&userID, &email, &passwordHash)
 	if err != nil {
 		log.Fatalf("管理者ユーザー検索エラー: %v", err)
@@ -98,4 +98,4 @@ func Run() {
 	log.Println("以下の認証情報でログインできるようになりました:")
 	log.Println("Email: admin@example.com")
 	log.Println("Password: password")
-} 
+}


### PR DESCRIPTION
## Summary
- move `check_keywords.go`, `check_user.go`, and `reset_password.go` into
  subdirectories to avoid mismatched package names
- run gofmt on moved files and main.go

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68424a6ae8c483229aa62b35cac8953f