### PR TITLE
Add tests for PredictLinearRegression

### DIFF
--- a/backend/internal/prediction/arima_test.go
+++ b/backend/internal/prediction/arima_test.go
@@ -1,0 +1,31 @@
+package prediction
+
+import "testing"
+
+func TestPredictLinearRegressionLength(t *testing.T) {
+	data := []float64{1, 2, 3, 4, 5}
+	horizon := 3
+
+	preds, err := PredictLinearRegression(data, horizon)
+	if err != nil {
+		t.Fatalf("PredictLinearRegression returned error: %v", err)
+	}
+	if len(preds) != horizon {
+		t.Fatalf("expected %d predictions, got %d", horizon, len(preds))
+	}
+}
+
+func TestPredictLinearRegressionNonNegative(t *testing.T) {
+	data := []float64{5, 4, 3, 2, 1}
+	horizon := 3
+
+	preds, err := PredictLinearRegression(data, horizon)
+	if err != nil {
+		t.Fatalf("PredictLinearRegression returned error: %v", err)
+	}
+	for i, p := range preds {
+		if p < 0 {
+			t.Fatalf("prediction %d is negative: %f", i, p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for PredictLinearRegression

## Testing
- `go test ./...` *(fails: forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_68424ce5f1448322bf4604e6963c56dd