### PR TITLE
Fix JWT_SECRET return value count in generateToken

### DIFF
--- a/backend/internal/auth/auth_service.go
+++ b/backend/internal/auth/auth_service.go
@@ -177,7 +177,7 @@ func (s *Service) generateToken(userID int, tokenType TokenType) (string, string
 	// Get JWT secret from environment
 	jwtSecret := os.Getenv("JWT_SECRET")
 	if jwtSecret == "" {
-		return "", errors.New("JWT_SECRET not set")
+		return "", "", errors.New("JWT_SECRET not set")
 	}
 
 	// Sign and get the complete encoded token as a string


### PR DESCRIPTION
## Summary
- fix incorrect return value count when JWT_SECRET is missing

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: forbidden to download modules)*
- `go build ./...` *(fails: forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_6842561ced58832286a064bf8041d564